### PR TITLE
Add null check on doc before attaching methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ function attachMethods(schema, res) {
 }
 
 function attachMethodsToDoc(doc, methods) {
+  if (!doc) return
   if (Object.keys(methods).length === 0) {
     return doc
   }


### PR DESCRIPTION
In the case of bad or old data that hasn't been migrated properly to a schema, the doc can be null and cause any call to fail such as find().